### PR TITLE
Better Vertex caching

### DIFF
--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -30,16 +30,15 @@ OutputVertex OutputRegisters::ToVertex(const Regs::ShaderConfig& config) {
     OutputVertex ret;
     // TODO(neobrain): Under some circumstances, up to 16 attributes may be output. We need to
     // figure out what those circumstances are and enable the remaining outputs then.
-    unsigned index = 0;
-    for (unsigned i = 0; i < 7; ++i) {
 
-        if (index >= g_state.regs.vs_output_total)
+    for (unsigned i = 0; i < 7; ++i) {
+        if (i >= g_state.regs.vs_output_total)
             break;
 
         if ((config.output_mask & (1 << i)) == 0)
             continue;
 
-        const auto& output_register_map = g_state.regs.vs_output_attributes[index];
+        const auto& output_register_map = g_state.regs.vs_output_attributes[i];
 
         u32 semantics[4] = {output_register_map.map_x, output_register_map.map_y,
                             output_register_map.map_z, output_register_map.map_w};
@@ -51,11 +50,9 @@ OutputVertex OutputRegisters::ToVertex(const Regs::ShaderConfig& config) {
             } else {
                 // Zero output so that attributes which aren't output won't have denormals in them,
                 // which would slow us down later.
-                memset(out, 0, sizeof(*out));
+                out->Zero();
             }
         }
-
-        index++;
     }
 
     // The hardware takes the absolute and saturates vertex colors like this, *before* doing


### PR DESCRIPTION
We can improve the vertex caching of Pica, by:
- Using a better caching data structure, having O(1) access time.
- Caching the output vertices, instead of the output registers

Consequence of the patch:
- Increases memory footprint slightly, since we increase
the size of the vertex cache.
- Performance increase, since more values are cached.
- Performance increase, since cache lookup time is now O(1).

From my performance analysis of Pokemon OR, I see that:
- ToVertex is a big hotspot (7% during intro scene)
- WritePicaReg is also a big hotspot (5% during the intro scene)