### PR TITLE
Framelimit

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -67,6 +67,8 @@ void Config::ReadValues() {
     Settings::values.use_scaled_resolution =
         sdl2_config->GetBoolean("Renderer", "use_scaled_resolution", false);
     Settings::values.use_vsync = sdl2_config->GetBoolean("Renderer", "use_vsync", false);
+    Settings::values.toggle_framelimit =
+        sdl2_config->GetBoolean("Renderer", "toggle_framelimit", false);
 
     Settings::values.bg_red = (float)sdl2_config->GetReal("Renderer", "bg_red", 1.0);
     Settings::values.bg_green = (float)sdl2_config->GetReal("Renderer", "bg_green", 1.0);

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -48,6 +48,7 @@ void Config::ReadValues() {
     Settings::values.use_scaled_resolution =
         qt_config->value("use_scaled_resolution", false).toBool();
     Settings::values.use_vsync = qt_config->value("use_vsync", false).toBool();
+    Settings::values.toggle_framelimit = qt_config->value("toggle_framelimit", true).toBool();
 
     Settings::values.bg_red = qt_config->value("bg_red", 1.0).toFloat();
     Settings::values.bg_green = qt_config->value("bg_green", 1.0).toFloat();

--- a/src/citra_qt/configure_graphics.cpp
+++ b/src/citra_qt/configure_graphics.cpp
@@ -23,6 +23,7 @@ void ConfigureGraphics::setConfiguration() {
     ui->toggle_shader_jit->setChecked(Settings::values.use_shader_jit);
     ui->toggle_scaled_resolution->setChecked(Settings::values.use_scaled_resolution);
     ui->toggle_vsync->setChecked(Settings::values.use_vsync);
+    ui->toggle_framelimit->setChecked(Settings::values.toggle_framelimit);
     ui->layout_combobox->setCurrentIndex(static_cast<int>(Settings::values.layout_option));
     ui->swap_screen->setChecked(Settings::values.swap_screen);
 }
@@ -32,6 +33,7 @@ void ConfigureGraphics::applyConfiguration() {
     Settings::values.use_shader_jit = ui->toggle_shader_jit->isChecked();
     Settings::values.use_scaled_resolution = ui->toggle_scaled_resolution->isChecked();
     Settings::values.use_vsync = ui->toggle_vsync->isChecked();
+    Settings::values.toggle_framelimit = ui->toggle_framelimit->isChecked();
     Settings::values.layout_option =
         static_cast<Settings::LayoutOption>(ui->layout_combobox->currentIndex());
     Settings::values.swap_screen = ui->swap_screen->isChecked();

--- a/src/citra_qt/configure_graphics.ui
+++ b/src/citra_qt/configure_graphics.ui
@@ -50,6 +50,13 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QCheckBox" name="toggle_framelimit">
+          <property name="text">
+           <string>Limit framerate</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>

--- a/src/core/hle/applets/erreula.cpp
+++ b/src/core/hle/applets/erreula.cpp
@@ -10,7 +10,7 @@ namespace HLE {
 namespace Applets {
 
 ResultCode ErrEula::ReceiveParameter(const Service::APT::MessageParameter& parameter) {
-    if (parameter.signal != static_cast<u32>(Service::APT::SignalType::LibAppJustStarted)) {
+    if (parameter.signal != static_cast<u32>(Service::APT::SignalType::Request)) {
         LOG_ERROR(Service_APT, "unsupported signal %u", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
@@ -36,7 +36,7 @@ ResultCode ErrEula::ReceiveParameter(const Service::APT::MessageParameter& param
 
     // Send the response message with the newly created SharedMemory
     Service::APT::MessageParameter result;
-    result.signal = static_cast<u32>(Service::APT::SignalType::LibAppFinished);
+    result.signal = static_cast<u32>(Service::APT::SignalType::Response);
     result.buffer.clear();
     result.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     result.sender_id = static_cast<u32>(id);
@@ -57,7 +57,7 @@ ResultCode ErrEula::StartImpl(const Service::APT::AppletStartupParameter& parame
     Service::APT::MessageParameter message;
     message.buffer.resize(parameter.buffer.size());
     std::fill(message.buffer.begin(), message.buffer.end(), 0);
-    message.signal = static_cast<u32>(Service::APT::SignalType::LibAppClosed);
+    message.signal = static_cast<u32>(Service::APT::SignalType::WakeupByExit);
     message.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     message.sender_id = static_cast<u32>(id);
     Service::APT::SendParameter(message);

--- a/src/core/hle/applets/mii_selector.cpp
+++ b/src/core/hle/applets/mii_selector.cpp
@@ -19,7 +19,7 @@ namespace HLE {
 namespace Applets {
 
 ResultCode MiiSelector::ReceiveParameter(const Service::APT::MessageParameter& parameter) {
-    if (parameter.signal != static_cast<u32>(Service::APT::SignalType::LibAppJustStarted)) {
+    if (parameter.signal != static_cast<u32>(Service::APT::SignalType::Request)) {
         LOG_ERROR(Service_APT, "unsupported signal %u", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
@@ -44,7 +44,7 @@ ResultCode MiiSelector::ReceiveParameter(const Service::APT::MessageParameter& p
 
     // Send the response message with the newly created SharedMemory
     Service::APT::MessageParameter result;
-    result.signal = static_cast<u32>(Service::APT::SignalType::LibAppFinished);
+    result.signal = static_cast<u32>(Service::APT::SignalType::Response);
     result.buffer.clear();
     result.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     result.sender_id = static_cast<u32>(id);
@@ -73,7 +73,7 @@ ResultCode MiiSelector::StartImpl(const Service::APT::AppletStartupParameter& pa
     Service::APT::MessageParameter message;
     message.buffer.resize(sizeof(MiiResult));
     std::memcpy(message.buffer.data(), &result, message.buffer.size());
-    message.signal = static_cast<u32>(Service::APT::SignalType::LibAppClosed);
+    message.signal = static_cast<u32>(Service::APT::SignalType::WakeupByExit);
     message.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     message.sender_id = static_cast<u32>(id);
     Service::APT::SendParameter(message);

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -22,7 +22,7 @@ namespace HLE {
 namespace Applets {
 
 ResultCode SoftwareKeyboard::ReceiveParameter(Service::APT::MessageParameter const& parameter) {
-    if (parameter.signal != static_cast<u32>(Service::APT::SignalType::LibAppJustStarted)) {
+    if (parameter.signal != static_cast<u32>(Service::APT::SignalType::Request)) {
         LOG_ERROR(Service_APT, "unsupported signal %u", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
@@ -47,7 +47,7 @@ ResultCode SoftwareKeyboard::ReceiveParameter(Service::APT::MessageParameter con
 
     // Send the response message with the newly created SharedMemory
     Service::APT::MessageParameter result;
-    result.signal = static_cast<u32>(Service::APT::SignalType::LibAppFinished);
+    result.signal = static_cast<u32>(Service::APT::SignalType::Response);
     result.buffer.clear();
     result.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     result.sender_id = static_cast<u32>(id);
@@ -108,7 +108,7 @@ void SoftwareKeyboard::Finalize() {
     Service::APT::MessageParameter message;
     message.buffer.resize(sizeof(SoftwareKeyboardConfig));
     std::memcpy(message.buffer.data(), &config, message.buffer.size());
-    message.signal = static_cast<u32>(Service::APT::SignalType::LibAppClosed);
+    message.signal = static_cast<u32>(Service::APT::SignalType::WakeupByExit);
     message.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     message.sender_id = static_cast<u32>(id);
     Service::APT::SendParameter(message);

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -22,6 +22,11 @@ SharedPtr<Event> Event::Create(ResetType reset_type, std::string name) {
     evt->reset_type = reset_type;
     evt->name = std::move(name);
 
+    if (reset_type == ResetType::Pulse) {
+        LOG_ERROR(Kernel, "Unimplemented event reset type Pulse");
+        UNIMPLEMENTED();
+    }
+
     return evt;
 }
 

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -31,6 +31,11 @@ SharedPtr<Timer> Timer::Create(ResetType reset_type, std::string name) {
     timer->interval_delay = 0;
     timer->callback_handle = timer_callback_handle_table.Create(timer).MoveFrom();
 
+    if (reset_type == ResetType::Pulse) {
+        LOG_ERROR(Kernel, "Unimplemented timer reset type Pulse");
+        UNIMPLEMENTED();
+    }
+
     return timer;
 }
 

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -523,7 +523,7 @@ void Init() {
     notification_event = Kernel::Event::Create(Kernel::ResetType::OneShot, "APT_U:Notification");
     parameter_event = Kernel::Event::Create(Kernel::ResetType::OneShot, "APT_U:Start");
 
-    next_parameter.signal = static_cast<u32>(SignalType::AppJustStarted);
+    next_parameter.signal = static_cast<u32>(SignalType::Wakeup);
     next_parameter.destination_id = 0x300;
 }
 

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -46,12 +46,23 @@ static_assert(sizeof(CaptureBufferInfo) == 0x20, "CaptureBufferInfo struct has i
 /// Signals used by APT functions
 enum class SignalType : u32 {
     None = 0x0,
-    AppJustStarted = 0x1,
-    LibAppJustStarted = 0x2,
-    LibAppFinished = 0x3,
-    LibAppClosed = 0xA,
-    ReturningToApp = 0xB,
-    ExitingApp = 0xC,
+    Wakeup = 0x1,
+    Request = 0x2,
+    Response = 0x3,
+    Exit = 0x4,
+    Message = 0x5,
+    HomeButtonSingle = 0x6,
+    HomeButtonDouble = 0x7,
+    DspSleep = 0x8,
+    DspWakeup = 0x9,
+    WakeupByExit = 0xA,
+    WakeupByPause = 0xB,
+    WakeupByCancel = 0xC,
+    WakeupByCancelAll = 0xD,
+    WakeupByPowerButtonClick = 0xE,
+    WakeupToJumpHome = 0xF,
+    RequestForSysApplet = 0x10,
+    WakeupToLaunchApplication = 0x11,
 };
 
 /// App Id's used by APT functions

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -4,6 +4,7 @@
 
 #include <cstring>
 #include <numeric>
+#include <thread>
 #include <type_traits>
 #include "common/color.h"
 #include "common/common_types.h"
@@ -39,6 +40,8 @@ static int vblank_event;
 static u64 frame_count;
 /// True if the last frame was skipped
 static bool last_skip_frame;
+/// Start clock for frame limiter
+std::chrono::high_resolution_clock::time_point timer = std::chrono::high_resolution_clock::now();
 
 template <typename T>
 inline void Read(T& var, const u32 raw_addr) {
@@ -547,6 +550,18 @@ static void VBlankCallback(u64 userdata, int cycles_late) {
 
     // Reschedule recurrent event
     CoreTiming::ScheduleEvent(frame_ticks - cycles_late, vblank_event);
+
+    // Frame limiting
+    if (Settings::values.toggle_framelimit) {
+        uint32_t time_diff = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                 std::chrono::high_resolution_clock::now() - timer)
+                                 .count();
+        static const float ex = 1000.0f / 60.0f;
+        if (time_diff < ex) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(long(ex - time_diff)));
+        }
+    }
+    timer = std::chrono::high_resolution_clock::now();
 }
 
 /// Initialize hardware

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -21,6 +21,7 @@ void Apply() {
     VideoCore::g_hw_renderer_enabled = values.use_hw_renderer;
     VideoCore::g_shader_jit_enabled = values.use_shader_jit;
     VideoCore::g_scaled_resolution_enabled = values.use_scaled_resolution;
+    VideoCore::g_toggle_framelimit_enabled = values.toggle_framelimit;
 
     if (VideoCore::g_emu_window) {
         auto layout = VideoCore::g_emu_window->GetFramebufferLayout();

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -91,6 +91,7 @@ struct Values {
     bool use_shader_jit;
     bool use_scaled_resolution;
     bool use_vsync;
+    bool toggle_framelimit;
 
     LayoutOption layout_option;
     bool swap_screen;

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -215,18 +215,17 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
 
         PrimitiveAssembler<Shader::OutputVertex>& primitive_assembler = g_state.primitive_assembler;
 
-        if (g_debug_context) {
+        if (g_debug_context && g_debug_context->recorder) {
             for (int i = 0; i < 3; ++i) {
                 const auto texture = regs.GetTextures()[i];
                 if (!texture.enabled)
                     continue;
 
                 u8* texture_data = Memory::GetPhysicalPointer(texture.config.GetPhysicalAddress());
-                if (g_debug_context && Pica::g_debug_context->recorder)
-                    g_debug_context->recorder->MemoryAccessed(
-                        texture_data, Pica::Regs::NibblesPerPixel(texture.format) *
-                                          texture.config.width / 2 * texture.config.height,
-                        texture.config.GetPhysicalAddress());
+                g_debug_context->recorder->MemoryAccessed(
+                    texture_data, Pica::Regs::NibblesPerPixel(texture.format) *
+                    texture.config.width / 2 * texture.config.height,
+                    texture.config.GetPhysicalAddress());
             }
         }
 

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -40,7 +40,7 @@ namespace Pica {
 //       field offset. Otherwise, the compiler will fail to compile this code.
 #define PICA_REG_INDEX_WORKAROUND(field_name, backup_workaround_index)                             \
     ((typename std::enable_if<backup_workaround_index == PICA_REG_INDEX(field_name),               \
-                              size_t>::type)PICA_REG_INDEX(field_name))
+                              size_t>::type) PICA_REG_INDEX(field_name))
 #endif // _MSC_VER
 
 struct Regs {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <memory>
+#include <thread>
 #include <glad/glad.h>
 #include "common/assert.h"
 #include "common/bit_field.h"

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <thread>
 #include <glad/glad.h>
 #include "common/common_types.h"
 #include "common/math_util.h"

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -21,6 +21,7 @@ std::atomic<bool> g_hw_renderer_enabled;
 std::atomic<bool> g_shader_jit_enabled;
 std::atomic<bool> g_scaled_resolution_enabled;
 std::atomic<bool> g_vsync_enabled;
+std::atomic<bool> g_toggle_framelimit_enabled;
 
 /// Initialize the video core
 bool Init(EmuWindow* emu_window) {

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -38,6 +38,7 @@ extern EmuWindow* g_emu_window;                  ///< Emu window
 extern std::atomic<bool> g_hw_renderer_enabled;
 extern std::atomic<bool> g_shader_jit_enabled;
 extern std::atomic<bool> g_scaled_resolution_enabled;
+extern std::atomic<bool> g_toggle_framelimit_enabled;
 
 /// Start the video core
 void Start();


### PR DESCRIPTION
here is a simple  framerate limiter. it  is based on a simple algo
      optimal_frame_time = 16.6666ms
      if ( average_frame_time < optimal_frame_time) {
  sleep(optimal_frame_time -average_frame_time)
       }
Frame information is gotten from the average frame time.frames are not locked to 60fps, but varies between 58-61.I have tested a few games on my own. framerates are maintain ~60fps, with no adverse side effects.
One problem is that, it is not accurate. i tried using the real frame time, but extra execution time used on preparing the next frame, causes the average frame time to increase, reducing frame rate. using the average frame time, the frame time was kept close to 16.66ms, with spikes of +-1ms. as long as a scene change does not cause a rapid change in real frame time, frame rate would be held constant. even if a spike occurs, it flattens out quickly. 
